### PR TITLE
Fix includes in OpenIMU300RI examples

### DIFF
--- a/examples/OpenIMU300RI/IMU/lib/Core/UARTComm/CommonMessages.c
+++ b/examples/OpenIMU300RI/IMU/lib/Core/UARTComm/CommonMessages.c
@@ -33,7 +33,7 @@ limitations under the License.
 #include "appVersion.h"
 #include "ucb_packet_struct.h"
 #include "magAPI.h"
-#include "magAlign.h"
+#include "MagAlign.h"
 
 #include "CommonMessages.h"
 #include "algorithm.h"

--- a/examples/OpenIMU300RI/IMU/src/user/UserAlgorithm.c
+++ b/examples/OpenIMU300RI/IMU/src/user/UserAlgorithm.c
@@ -35,7 +35,7 @@ limitations under the License.
 
 #include "algorithm.h"
 #include "EKF_Algorithm.h"
-#include "BitStatus.h"
+#include "BITStatus.h"
 #include "UserConfiguration.h"
 #include "bsp.h"
 #include "debug.h"

--- a/examples/OpenIMU300RI/IMU/src/user/UserConfiguration.c
+++ b/examples/OpenIMU300RI/IMU/src/user/UserConfiguration.c
@@ -32,7 +32,7 @@ limitations under the License.
 #include "userAPI.h"
 
 #include "UserConfiguration.h"
-#include "UserMessagingUart.h"
+#include "UserMessagingUART.h"
 #include "eepromAPI.h"
 #include "Indices.h"
 #include "sae_j1939.h"

--- a/examples/OpenIMU300RI/INS/lib/Core/UARTComm/CommonMessages.c
+++ b/examples/OpenIMU300RI/INS/lib/Core/UARTComm/CommonMessages.c
@@ -33,7 +33,7 @@ limitations under the License.
 #include "appVersion.h"
 #include "ucb_packet_struct.h"
 #include "magAPI.h"
-#include "magAlign.h"
+#include "MagAlign.h"
 
 #include "CommonMessages.h"
 #include "algorithm.h"

--- a/examples/OpenIMU300RI/INS/src/user/UserAlgorithm.c
+++ b/examples/OpenIMU300RI/INS/src/user/UserAlgorithm.c
@@ -36,7 +36,7 @@ limitations under the License.
 
 #include "algorithm.h"
 #include "EKF_Algorithm.h"
-#include "BitStatus.h"
+#include "BITStatus.h"
 #include "UserConfiguration.h"
 #include "bsp.h"
 #include "debug.h"

--- a/examples/OpenIMU300RI/INS/src/user/UserConfiguration.c
+++ b/examples/OpenIMU300RI/INS/src/user/UserConfiguration.c
@@ -32,7 +32,7 @@ limitations under the License.
 #include "userAPI.h"
 
 #include "UserConfiguration.h"
-#include "UserMessagingUart.h"
+#include "UserMessagingUART.h"
 #include "eepromAPI.h"
 #include "Indices.h"
 #include "sae_j1939.h"

--- a/examples/OpenIMU300RI/INS/src/user/UserMessagingUART.c
+++ b/examples/OpenIMU300RI/INS/src/user/UserMessagingUART.c
@@ -32,7 +32,7 @@ limitations under the License.
 #include "sensorsAPI.h"
 #include "userAPI.h"
 #include "magAPI.h"
-#include "magAlign.h"
+#include "MagAlign.h"
 #include "appVersion.h"
 
 #include "UserMessagingUART.h"

--- a/examples/OpenIMU300RI/VG_AHRS/lib/Core/UARTComm/CommonMessages.c
+++ b/examples/OpenIMU300RI/VG_AHRS/lib/Core/UARTComm/CommonMessages.c
@@ -33,7 +33,7 @@ limitations under the License.
 #include "appVersion.h"
 #include "ucb_packet_struct.h"
 #include "magAPI.h"
-#include "magAlign.h"
+#include "MagAlign.h"
 
 #include "CommonMessages.h"
 #include "algorithm.h"

--- a/examples/OpenIMU300RI/VG_AHRS/src/user/UserConfiguration.c
+++ b/examples/OpenIMU300RI/VG_AHRS/src/user/UserConfiguration.c
@@ -32,7 +32,7 @@ limitations under the License.
 #include "userAPI.h"
 
 #include "UserConfiguration.h"
-#include "UserMessagingUart.h"
+#include "UserMessagingUART.h"
 #include "eepromAPI.h"
 #include "Indices.h"
 #include "sae_j1939.h"

--- a/examples/OpenIMU300RI/VG_AHRS/src/user/UserMessagingUART.c
+++ b/examples/OpenIMU300RI/VG_AHRS/src/user/UserMessagingUART.c
@@ -32,7 +32,7 @@ limitations under the License.
 #include "sensorsAPI.h"
 #include "userAPI.h"
 #include "magAPI.h"
-#include "magAlign.h"
+#include "MagAlign.h"
 #include "appVersion.h"
 
 #include "UserMessagingUART.h"


### PR DESCRIPTION
Hi,
I fixed some misspelled includes in the examples for the `OpenIMU300RI`.
To build correctly they also require a [fix](https://github.com/Aceinna/openIMU300-lib/pull/6) in the library itself, for which I have already opened a PR.