### PR TITLE
Fix include spelling issue

### DIFF
--- a/examples/OpenIMU300ZI/IMU/lib/Core/UARTComm/CommonMessages.c
+++ b/examples/OpenIMU300ZI/IMU/lib/Core/UARTComm/CommonMessages.c
@@ -33,7 +33,7 @@ limitations under the License.
 #include "appVersion.h"
 #include "ucb_packet_struct.h"
 #include "magAPI.h"
-#include "magAlign.h"
+#include "MagAlign.h"
 
 #include "CommonMessages.h"
 #include "algorithm.h"

--- a/examples/OpenIMU300ZI/IMU/src/user/UserMessagingSPI.c
+++ b/examples/OpenIMU300ZI/IMU/src/user/UserMessagingSPI.c
@@ -35,7 +35,7 @@ limitations under the License.
 #include "spiAPI.h"
 #include "magAPI.h"
 #include "appVersion.h"
-#include "BitStatus.h"
+#include "BITStatus.h"
 
 uint8_t  _spiDataBuf[2][SPI_DATA_BUF_LEN];
 uint8_t  *_activeSpiDataBufPtr = _spiDataBuf[0];

--- a/examples/OpenIMU300ZI/INS/lib/Core/UARTComm/CommonMessages.c
+++ b/examples/OpenIMU300ZI/INS/lib/Core/UARTComm/CommonMessages.c
@@ -33,7 +33,7 @@ limitations under the License.
 #include "appVersion.h"
 #include "ucb_packet_struct.h"
 #include "magAPI.h"
-#include "magAlign.h"
+#include "MagAlign.h"
 
 #include "CommonMessages.h"
 #include "algorithm.h"

--- a/examples/OpenIMU300ZI/INS/src/user/UserMessagingSPI.c
+++ b/examples/OpenIMU300ZI/INS/src/user/UserMessagingSPI.c
@@ -35,7 +35,7 @@ limitations under the License.
 #include "spiAPI.h"
 #include "magAPI.h"
 #include "appVersion.h"
-#include "BitStatus.h"
+#include "BITStatus.h"
 #include "EKF_Algorithm.h"
 
 uint8_t  _spiDataBuf[2][SPI_DATA_BUF_LEN];

--- a/examples/OpenIMU300ZI/VG_AHRS/lib/Core/UARTComm/CommonMessages.c
+++ b/examples/OpenIMU300ZI/VG_AHRS/lib/Core/UARTComm/CommonMessages.c
@@ -33,7 +33,7 @@ limitations under the License.
 #include "appVersion.h"
 #include "ucb_packet_struct.h"
 #include "magAPI.h"
-#include "magAlign.h"
+#include "MagAlign.h"
 
 #include "CommonMessages.h"
 #include "algorithm.h"

--- a/examples/OpenIMU300ZI/VG_AHRS/src/user/UserMessagingSPI.c
+++ b/examples/OpenIMU300ZI/VG_AHRS/src/user/UserMessagingSPI.c
@@ -35,7 +35,7 @@ limitations under the License.
 #include "spiAPI.h"
 #include "magAPI.h"
 #include "appVersion.h"
-#include "BitStatus.h"
+#include "BITStatus.h"
 #include "EKF_Algorithm.h"
 
 uint8_t  _spiDataBuf[2][SPI_DATA_BUF_LEN];


### PR DESCRIPTION
Assuming that it can compile if OS ignore case (Windows), but it won't on OS that take care of (Linux).  This 2 case spelling fix it.